### PR TITLE
separate training and validation data

### DIFF
--- a/download.py
+++ b/download.py
@@ -57,6 +57,9 @@ def unzip(filepath):
     os.remove(filepath)
 
 def download_celeb_a(dirpath):
+    NUM_EXAMPLES = 202599
+    TRAIN_STOP = 162770
+    VALID_STOP = 182637
     data_dir = 'celebA'
     if os.path.exists(os.path.join(dirpath, data_dir)):
         print('Found Celeb-A - skip')
@@ -68,6 +71,31 @@ def download_celeb_a(dirpath):
         zip_dir = zf.namelist()[0]
         zf.extractall(dirpath)
     os.remove(filepath)
+
+    # now split data into train/valid/test
+    train_dir = os.path.join(dirpath, zip_dir, 'train')
+    valid_dir = os.path.join(dirpath, zip_dir, 'valid')
+    test_dir = os.path.join(dirpath, zip_dir, 'test')
+    if not os.path.exists(train_dir):
+        os.makedirs(train_dir)
+    if not os.path.exists(valid_dir):
+        os.makedirs(valid_dir)
+    if not os.path.exists(test_dir):
+        os.makedirs(test_dir)
+    zip_path = os.path.join(dirpath, zip_dir)
+    for i in range(NUM_EXAMPLES):
+        image_filename = "{:06d}.jpg".format(i+1)
+        candidate_file = os.path.join(zip_path, image_filename)
+        if os.path.exists(candidate_file):
+            if i < TRAIN_STOP:
+                dest_dir = train_dir
+            elif i < VALID_STOP:
+                dest_dir = valid_dir
+            else:
+                dest_dir = test_dir
+            dest_file = os.path.join(dest_dir, image_filename)
+            os.rename(candidate_file, dest_file)
+
     os.rename(os.path.join(dirpath, zip_dir), os.path.join(dirpath, data_dir))
 
 def _list_categories(tag):

--- a/model.py
+++ b/model.py
@@ -105,6 +105,8 @@ class DCGAN(object):
         sample_images = np.array(sample).astype(np.float32)
         sample_input_images = np.array(sample_inputs).astype(np.float32)
 
+        save_images(sample_images, [8, 8], './samples/reference.png')
+
         counter = 1
         start_time = time.time()
 

--- a/model.py
+++ b/model.py
@@ -88,8 +88,8 @@ class DCGAN(object):
 
     def train(self, config):
         """Train DCGAN"""
-        data = glob(os.path.join("./data", config.dataset, "*.jpg"))
-        #np.random.shuffle(data)
+        # first setup validation data
+        data = sorted(glob(os.path.join("./data", config.dataset, "valid", "*.jpg")))
 
         g_optim = tf.train.AdamOptimizer(config.learning_rate, beta1=config.beta1) \
                           .minimize(self.g_loss, var_list=self.g_vars)
@@ -113,8 +113,11 @@ class DCGAN(object):
         else:
             print(" [!] Load failed...")
 
+        # we only save the validation inputs once
+        have_saved_inputs = False
+
         for epoch in xrange(config.epoch):
-            data = glob(os.path.join("./data", config.dataset, "*.jpg"))
+            data = sorted(glob(os.path.join("./data", config.dataset, "train", "*.jpg")))
             batch_idxs = min(len(data), config.train_size) // config.batch_size
 
             for idx in xrange(0, batch_idxs):
@@ -139,10 +142,11 @@ class DCGAN(object):
                         [self.G, self.g_loss, self.up_inputs],
                         feed_dict={self.inputs: sample_input_images, self.images: sample_images}
                     )
+                    if not have_saved_inputs:
+                        save_images(up_inputs, [8, 8], './samples/inputs.png')
+                        have_saved_inputs = True
                     save_images(samples, [8, 8],
-                                './samples/train_%s_%s.png' % (epoch, idx))
-                    save_images(up_inputs, [8, 8],
-                                './samples/inputs_%s_%s.png' % (epoch, idx))
+                                './samples/valid_%s_%s.png' % (epoch, idx))
                     print("[Sample] g_loss: %.8f" % (g_loss))
 
                 if np.mod(counter, 500) == 2:


### PR DESCRIPTION
It looked like the training routine was training on all of the celeba data, and then showing the results on a subset of that data. This changes the download routine to partition the celeba data into the canonical train/validation/test splits. The model then only trains on the training data, and outputs results based on the validation data.

I haven't seen any notable difference in the outputs, but this version would seem to be a more through test of the algorithm. Here is an example of the result after making the change and training for 6 epochs:

![valid_triple](https://cloud.githubusercontent.com/assets/945979/19191329/77bd819e-8cfe-11e6-9011-e26c73828833.png)

The top row is the input, the middle row is the output, and the bottom row is the ground truth. For comparison, here is a version before making this proposed change after roughly the same amount of training:

![train_triple](https://cloud.githubusercontent.com/assets/945979/19191429/e38bb350-8cfe-11e6-8eb6-21cd3a402efc.png)

A couple of other changes  - the input image is now output only once (because it does not change) and this ground truth image is also now output.

~~(Also note that this is currently downstream from #7, but I can rebase to make this separate if desired.)~~