### PR TITLE
updates to support batch_size != 64

### DIFF
--- a/model.py
+++ b/model.py
@@ -17,7 +17,7 @@ def doresize(x, shape):
 
 class DCGAN(object):
     def __init__(self, sess, image_size=128, is_crop=True,
-                 batch_size=64, sample_size = 64, image_shape=[128, 128, 3],
+                 batch_size=64, image_shape=[128, 128, 3],
                  y_dim=None, z_dim=100, gf_dim=64, df_dim=64,
                  gfc_dim=1024, dfc_dim=1024, c_dim=3, dataset_name='default',
                  checkpoint_dir=None):
@@ -39,7 +39,7 @@ class DCGAN(object):
         self.batch_size = batch_size
         self.image_size = image_size
         self.input_size = 32
-        self.sample_size = sample_size
+        self.sample_size = batch_size
         self.image_shape = image_shape
 
         self.y_dim = y_dim
@@ -105,6 +105,7 @@ class DCGAN(object):
         sample_images = np.array(sample).astype(np.float32)
         sample_input_images = np.array(sample_inputs).astype(np.float32)
 
+        save_images(sample_input_images, [8, 8], './samples/inputs_small.png')
         save_images(sample_images, [8, 8], './samples/reference.png')
 
         counter = 1

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,8 @@ def get_image(image_path, image_size, is_crop=True):
     return transform(imread(image_path), image_size, is_crop)
 
 def save_images(images, size, image_path):
-    return imsave(inverse_transform(images), size, image_path)
+    num_im = size[0] * size[1]
+    return imsave(inverse_transform(images[:num_im]), size, image_path)
 
 def imread(path):
     return scipy.misc.imread(path).astype(np.float)


### PR DESCRIPTION
The code did not support sample_size != batch_size,
so dropped sample_size as a parameter to the model constructor.

To support this, save_images was updated to clip the number
of images saved at rows * cols.

In addition the validation inputs are now also saved at their native
size. This file is called inputs_small.png.