### PR TITLE
Specify which axis to squeeze during phase shift.

### DIFF
--- a/subpixel.py
+++ b/subpixel.py
@@ -9,9 +9,9 @@ def _phase_shift(I, r):
     X = tf.reshape(I, (bsize, a, b, r, r))
     X = tf.transpose(X, (0, 1, 2, 4, 3))  # bsize, a, b, 1, 1
     X = tf.split(1, a, X)  # a, [bsize, b, r, r]
-    X = tf.concat(2, [tf.squeeze(x) for x in X])  # bsize, b, a*r, r
+    X = tf.concat(2, [tf.squeeze(x, axis=1) for x in X])  # bsize, b, a*r, r
     X = tf.split(1, b, X)  # b, [bsize, a*r, r]
-    X = tf.concat(2, [tf.squeeze(x) for x in X])  # bsize, a*r, b*r
+    X = tf.concat(2, [tf.squeeze(x, axis=1) for x in X])  # bsize, a*r, b*r
     return tf.reshape(X, (bsize, a*r, b*r, 1))
 
 


### PR DESCRIPTION
This fixes an issue where phase shift would fail on single-element batches.