### PR TITLE
Fix mnist file name and unzip command

### DIFF
--- a/download.py
+++ b/download.py
@@ -141,7 +141,7 @@ def download_mnist(dirpath):
     else:
         os.mkdir(data_dir)
     url_base = 'http://yann.lecun.com/exdb/mnist/' 
-    file_names = ['train-images-idx3-ubyte.gz','train-labels-idx1-ubyte.gz','t10k-images-idx3-ubyte.gz','t10k-labels-idx3-ubyte.gz']
+    file_names = ['train-images-idx3-ubyte.gz','train-labels-idx1-ubyte.gz','t10k-images-idx3-ubyte.gz','t10k-labels-idx1-ubyte.gz']
     for file_name in file_names:
         url = (url_base+file_name).format(**locals())
         print(url)
@@ -149,7 +149,8 @@ def download_mnist(dirpath):
         cmd = ['curl', url, '-o', out_path]
         print('Downloading ', file_name)
         subprocess.call(cmd)
-        cmd = ['gzip -d', out_path]
+        cmd = ['gzip', '-d', out_path]
+        print(cmd)
         print('Decompressing ', file_name)
         subprocess.call(cmd)
 


### PR DESCRIPTION
Some errors have occurred when run command 'python download.py --dataset mnist':
1.  command 'cmd = ['gzip -d', out_path]' will make the following error:
    FileNotFoundError: [Errno 2] No such file or directory: 'gzip -d'
2. t10k-labels-idx3-ubyte.gz should be t10k-labels-idx1-ubyte.gz.